### PR TITLE
Fixes for HA 2025.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,3 +56,14 @@
 - Προσθήκη νέου αρχείου κώδικα για εμφάνιση στην **Υγεία Συστήματος** του Home Assistant.
 - Κάλυψη παραγωγικού κώδικα με δοκιμές στο **100%**.
 - Ανανέωση αρχείου README.md μετά την προσθήκη της ενσωμάτωσης στον κατάλογο του HACS store.
+
+
+## v2.0.0 - Fixes for HA 2025.11 (2025-11-20)
+
+- Reformation of StatisticMetaData, because requires unit_class to be declared in order to be valid for async_import_statistics.
+- Contributor: [Kehayeah](https://github.com/Kehayeah)
+
+## v2.0.0 - Διορθώσεις για την έκδοση ΗΑ 2025.11 (20-11-2025)
+
+- Αναμόρφωση της StatisticMetaData, επειδή απαιτεί τη δήλωση της unit_class για να είναι έγκυρη για την async_import_statistics.
+- Συνεισφέρων: [Kehayeah](https://github.com/Kehayeah)

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Persistent notifications will inform you of successful token renewal or any erro
 
 | **Integration Version** |  **HA Compatibility**  |
 |---------------------|--------------------|
-|       **1.1.0**         | **2025.11 or older**   |
+|       **1.1.0**         | **2025.10 or older**   |
 |       **2.0.0**         | **2025.11 or newer**   |
 
 <h2 id="compatibility_el-section">⚖️ Συμβατότητα & Απαιτήσεις</h2>
@@ -154,7 +154,7 @@ Persistent notifications will inform you of successful token renewal or any erro
 
 | **Έκδοση Ενσωμάτωσης** | **Συμβατότητα Έκδοσης HA** |
 |--------------------|------------------------|
-|       **1.1.0**        | **2025.11 ή παλαιότερη**   |
+|       **1.1.0**        | **2025.10 ή παλαιότερη**   |
 |       **2.0.0**        | **2025.11 ή νεότερη**      |
 
 ---

--- a/README.md
+++ b/README.md
@@ -142,10 +142,20 @@ Persistent notifications will inform you of successful token renewal or any erro
 - Home Assistant Core **2024.10** or newer
 - Telemetry feature enabled on your electricity meter
 
+| **Integration Version** |  **HA Compatibility**  |
+|---------------------|--------------------|
+|       **1.1.0**         | **2025.11 or older**   |
+|       **2.0.0**         | **2025.11 or newer**   |
+
 <h2 id="compatibility_el-section">⚖️ Συμβατότητα & Απαιτήσεις</h2>
 
  - Home Assistant Core **2024.10** ή νεότερη έκδοση
  - Ενεργοποιημένη υπηρεσία τηλεμετρίας στον μετρητή σας
+
+| **Έκδοση Ενσωμάτωσης** | **Συμβατότητα Έκδοσης HA** |
+|--------------------|------------------------|
+|       **1.1.0**        | **2025.11 ή παλαιότερη**   |
+|       **2.0.0**        | **2025.11 ή νεότερη**      |
 
 ---
 

--- a/custom_components/deddie_metering/helpers/statistics.py
+++ b/custom_components/deddie_metering/helpers/statistics.py
@@ -110,7 +110,7 @@ async def update_future_statistics(
         has_mean=False,
         has_sum=True,
         mean_type=StatisticMeanType.NONE,
-        unit_class=SensorDeviceClass.ENERGY
+        unit_class=SensorDeviceClass.ENERGY,
     )
     # Καλείται η async_import_statistics μέσα σε async_add_executor_job
     await hass.async_add_executor_job(

--- a/custom_components/deddie_metering/helpers/statistics.py
+++ b/custom_components/deddie_metering/helpers/statistics.py
@@ -11,6 +11,7 @@ from homeassistant.components.recorder.statistics import (
 from homeassistant.const import UnitOfEnergy
 from sqlalchemy import text
 
+from homeassistant.components.sensor import SensorDeviceClass
 
 _LOGGER = logging.getLogger("deddie_metering")
 
@@ -109,6 +110,7 @@ async def update_future_statistics(
         has_mean=False,
         has_sum=True,
         mean_type=StatisticMeanType.NONE,
+        unit_class=SensorDeviceClass.ENERGY
     )
     # Καλείται η async_import_statistics μέσα σε async_add_executor_job
     await hass.async_add_executor_job(

--- a/custom_components/deddie_metering/helpers/utils.py
+++ b/custom_components/deddie_metering/helpers/utils.py
@@ -117,7 +117,7 @@ async def process_and_insert(
             has_mean=False,
             has_sum=True,
             mean_type=StatisticMeanType.NONE,
-            unit_class=SensorDeviceClass.ENERGY
+            unit_class=SensorDeviceClass.ENERGY,
         )
         # Εισαγωγή/ενημέρωση των στατιστικών εγγραφών μέσω async_import_statistics
         await hass.async_add_executor_job(

--- a/custom_components/deddie_metering/helpers/utils.py
+++ b/custom_components/deddie_metering/helpers/utils.py
@@ -9,6 +9,7 @@ from homeassistant.components.recorder.statistics import (
     StatisticMeanType,
 )
 from homeassistant.const import UnitOfEnergy
+from homeassistant.components.sensor import SensorDeviceClass
 from .storage import (
     load_last_total,
     save_last_total,
@@ -18,6 +19,7 @@ from .storage import (
 from .statistics import run_update_future_statistics
 from ..api.client import get_data_from_api
 from ..const import ATTR_PRODUCTION, ATTR_INJECTION, ATTR_CONSUMPTION
+
 
 _LOGGER = logging.getLogger("deddie_metering")
 
@@ -115,6 +117,7 @@ async def process_and_insert(
             has_mean=False,
             has_sum=True,
             mean_type=StatisticMeanType.NONE,
+            unit_class=SensorDeviceClass.ENERGY
         )
         # Εισαγωγή/ενημέρωση των στατιστικών εγγραφών μέσω async_import_statistics
         await hass.async_add_executor_job(

--- a/custom_components/deddie_metering/manifest.json
+++ b/custom_components/deddie_metering/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/mike81gr/deddie-metering/issues",
   "requirements": [],
   "version": "2.0.0",
-  "homeassistant": "2025.11.0"
+  "homeassistant": "2025.11"
 }

--- a/custom_components/deddie_metering/manifest.json
+++ b/custom_components/deddie_metering/manifest.json
@@ -10,6 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/mike81gr/deddie-metering/issues",
   "requirements": [],
-  "version": "2.0.0",
-  "homeassistant": "2025.11"
+  "version": "2.0.0"
 }

--- a/custom_components/deddie_metering/manifest.json
+++ b/custom_components/deddie_metering/manifest.json
@@ -10,5 +10,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/mike81gr/deddie-metering/issues",
   "requirements": [],
-  "version": "1.1.0"
+  "version": "2.0.0",
+  "homeassistant": "2025.11.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
   "name": "ΔΕΔΔΗΕ Τηλεμετρία Καταναλώσεων",
   "content_in_root": false,
   "render_readme": true,
-  "homeassistant": "2024.10",
+  "homeassistant": "2025.11",
   "country": "GR",
   "zip_release": true,
   "filename": "deddie_metering.zip"


### PR DESCRIPTION
Starting from HA version 2025.11, StatisticMetaData requires unit_class to be declared in order to be valid for async_import_statistics.

This PR adds that property with value "SensorDeviceClass.ENERGY" as defined in the docs https://developers.home-assistant.io/docs/core/entity/sensor/